### PR TITLE
Use relative URLs

### DIFF
--- a/templates/scripts.html
+++ b/templates/scripts.html
@@ -1,1 +1,1 @@
-<script src="/static/plugins/ep_stats/static/js/main.js"></script>
+<script src="../static/plugins/ep_stats/static/js/main.js"></script>


### PR DESCRIPTION
Absolute URLs break users that serve Etherpad from a subdirectory.