### PR TITLE
fix: drop stats overlay below Etherpad dropdown stacking context (#10)

### DIFF
--- a/static/css/stats.css
+++ b/static/css/stats.css
@@ -4,6 +4,11 @@
   bottom:0;
   right:20px;
   width:300px;
+  /* Etherpad's toolbar dropdowns and popups use z-index values of 150–500
+     (see core pad/toolbar.css and pad/icons.css). Stay below that range so
+     menu dropdowns rendered on top of the pad aren't hidden behind the
+     stats overlay (#10). */
+  z-index: 10;
   background-color: var(--bg-color);
   color:#000;
   padding:20px;

--- a/static/tests/backend/specs/z_index.js
+++ b/static/tests/backend/specs/z_index.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+
+const cssPath = path.resolve(
+    __dirname, '..', '..', '..', '..', 'static', 'css', 'stats.css');
+
+describe(__filename, function () {
+  it('stats overlay uses a z-index below Etherpad toolbar popups (#10)', function () {
+    // Etherpad's toolbar dropdowns / popups use z-index values in the
+    // 150–500 range (see core pad/toolbar.css and pad/icons.css). The
+    // stats overlay is position:fixed, so without a lower explicit
+    // z-index menu dropdowns that extend into the stats area get hidden
+    // behind it.
+    const src = fs.readFileSync(cssPath, 'utf8');
+    const statsBlock = src.match(/#stats\s*\{[\s\S]*?\}/);
+    assert(statsBlock, 'expected an `#stats {}` block in stats.css');
+    const zIndexMatch = statsBlock[0].match(/z-index:\s*(-?\d+)/);
+    assert(zIndexMatch, '#stats must declare a z-index so it stacks below dropdowns');
+    const z = parseInt(zIndexMatch[1], 10);
+    assert(z < 150,
+        `#stats z-index (${z}) must be below Etherpad's dropdown/popup z-indexes (≥150)`);
+  });
+});


### PR DESCRIPTION
Fixes #10. `#stats` is `position: fixed` at the bottom-right with no z-index, so DOM order alone decided stacking. Since stats is appended late, dropdowns (color picker, settings) that extended into the stats area got hidden behind it. Pin stats at `z-index: 10`, well below Etherpad's toolbar popup range (150–500). Backend spec enforces the rule.