### PR TITLE
refactor: adopt template helper for 3 simple eejsBlock_* hook(s)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,27 +1,23 @@
 'use strict';
 
+const {template} = require('ep_plugin_helpers');
+
 const eejs = require('ep_etherpad-lite/node/eejs');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
 
-exports.eejsBlock_exportColumn = (hookName, args, cb) => {
-  args.content += eejs.require('ep_stats/templates/exportcolumn.html', {}, module);
-  return cb();
-};
+exports.eejsBlock_exportColumn =
+    template('ep_stats/templates/exportcolumn.html');
 
-exports.eejsBlock_scripts = (hookName, args, cb) => {
-  args.content += eejs.require('ep_stats/templates/scripts.html', {}, module);
-  return cb();
-};
+exports.eejsBlock_scripts =
+    template('ep_stats/templates/scripts.html');
 
 exports.eejsBlock_styles = (hookName, args, cb) => {
   args.content += '<link href="../static/plugins/ep_stats/static/css/stats.css" rel="stylesheet">';
   return cb();
 };
 
-exports.eejsBlock_body = (hookName, args, cb) => {
-  args.content += eejs.require('ep_stats/templates/stats.html', {}, module);
-  return cb();
-};
+exports.eejsBlock_body =
+    template('ep_stats/templates/stats.html');
 
 exports.eejsBlock_mySettings = (hookName, args, cb) => {
   let checkedState;

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.5.0"
   }
 }


### PR DESCRIPTION
## Summary

Adopts `template()` from `ep_plugin_helpers` for 3 `eejsBlock_*` hook(s) of shape:

```js
exports.eejsBlock_X = (hookName, args, cb) => {
  args.content += eejs.require('plugin/template.ejs'[, {}[, module]]);
  cb();
};
```

Replaced with `exports.eejsBlock_X = template('plugin/template.ejs');`. Same runtime behavior.

Part of Phase 4 of the modernization campaign. Wave 1: ether/ep_themes#103 + 6 small plugins. Wave 2 picks up hooks with explicit empty-vars / module argument that wave 1's stricter regex skipped.