### PR TITLE
helpers: adopt padToggle for "Show Pad and Author stats" setting

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -1,19 +1,22 @@
 {
-  "parts":[
+  "parts": [
     {
       "name": "stats",
-      "hooks":{
+      "hooks": {
         "expressCreateServer": "ep_stats/express",
+        "loadSettings": "ep_stats/index",
+        "clientVars": "ep_stats/index",
         "eejsBlock_exportColumn": "ep_stats/index",
         "eejsBlock_scripts": "ep_stats/index",
         "eejsBlock_mySettings": "ep_stats/index",
-        "eejsBlock_styles":"ep_stats/index",
-        "eejsBlock_body":"ep_stats/index",
-        "eejsBlock_dd_view":"ep_stats/index"
+        "eejsBlock_padSettings": "ep_stats/index",
+        "eejsBlock_styles": "ep_stats/index",
+        "eejsBlock_body": "ep_stats/index"
       },
       "client_hooks": {
         "postAceInit": "ep_stats/static/js/stats",
-        "aceEditEvent": "ep_stats/static/js/stats"
+        "aceEditEvent": "ep_stats/static/js/stats",
+        "handleClientMessage_CLIENT_MESSAGE": "ep_stats/static/js/stats:handleClientMessage_CLIENT_MESSAGE"
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -1,9 +1,36 @@
 'use strict';
 
 const {template} = require('ep_plugin_helpers');
+const {padToggle} = require('ep_plugin_helpers/pad-toggle-server');
 
-const eejs = require('ep_etherpad-lite/node/eejs');
-const settings = require('ep_etherpad-lite/node/utils/Settings');
+// Parallel User Settings + Pad Wide Settings checkboxes for "Show Pad and
+// Author stats". Helper owns markup, storage, broadcast, enforce, and i18n.
+const statsToggle = padToggle({
+  pluginName: 'ep_stats',
+  settingId: 'stats',
+  l10nId: 'ep_stats.stats_entry.show_pad_and_author_stats',
+  defaultLabel: 'Show Pad and Author stats',
+  defaultEnabled: true,
+});
+
+// Older settings.json used a top-level `ep_stats_default` key. Translate it
+// to the helper's nested `ep_stats.defaultEnabled` so an admin who set it
+// to `false` keeps a default-off pad.
+exports.loadSettings = async (hookName, args) => {
+  const root = args && args.settings;
+  if (root) {
+    const ps = (root.ep_stats = root.ep_stats || {});
+    if (typeof ps.defaultEnabled !== 'boolean' &&
+        typeof root.ep_stats_default === 'boolean') {
+      ps.defaultEnabled = root.ep_stats_default;
+    }
+  }
+  return statsToggle.loadSettings(hookName, args);
+};
+
+exports.clientVars = statsToggle.clientVars;
+exports.eejsBlock_mySettings = statsToggle.eejsBlock_mySettings;
+exports.eejsBlock_padSettings = statsToggle.eejsBlock_padSettings;
 
 exports.eejsBlock_exportColumn =
     template('ep_stats/templates/exportcolumn.html');
@@ -18,21 +45,3 @@ exports.eejsBlock_styles = (hookName, args, cb) => {
 
 exports.eejsBlock_body =
     template('ep_stats/templates/stats.html');
-
-exports.eejsBlock_mySettings = (hookName, args, cb) => {
-  let checkedState;
-  if (!settings.ep_stats_default) {
-    checkedState = 'unchecked';
-  } else if (settings.ep_stats_default === true) {
-    checkedState = 'checked';
-  }
-  args.content += eejs.require('ep_stats/templates/stats_entry.ejs', {checked: checkedState});
-  return cb();
-};
-
-
-exports.eejsBlock_dd_view = (hookName, args, cb) => {
-  args.content +=
-      "<li><a href='#' onClick='$(\"#options-stats\").click();'>Pad Statistics</a></li>";
-  return cb();
-};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "ep_plugin_helpers": "^0.5.0"
+    "ep_plugin_helpers": "^0.5.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       ep_plugin_helpers:
-        specifier: ^0.5.0
+        specifier: ^0.5.2
         version: 0.5.2
     devDependencies:
       eslint:

--- a/static/css/stats.css
+++ b/static/css/stats.css
@@ -31,3 +31,11 @@
 .statsAuthorColor{
   width:4px;
 }
+
+/* Hide the stats panel in core's in-pad history mode (Etherpad #7659).
+   Stats reflect the live pad; they have no meaning when the pad is showing
+   a historical revision, and the panel's bottom-right position overlaps
+   core's history banner (the "Return to live" button in particular). The
+   class is added to <body> by core when entering history and removed when
+   the user returns to live. */
+body.history-mode #stats { display: none !important; }

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -1,5 +1,23 @@
 'use strict';
 
+// Sub-path import keeps the client bundle clean — the top-level
+// `ep_plugin_helpers` index pulls in server-only modules.
+const {padToggle} = require('ep_plugin_helpers/pad-toggle');
+
+// Same config as the server-side instance — must agree on pluginName,
+// settingId, l10nId, and defaultLabel so checkbox ids and clientVars line up.
+const statsToggle = padToggle({
+  pluginName: 'ep_stats',
+  settingId: 'stats',
+  l10nId: 'ep_stats.stats_entry.show_pad_and_author_stats',
+  defaultLabel: 'Show Pad and Author stats',
+  defaultEnabled: true,
+});
+
+// Re-export so the helper sees pad-wide broadcasts and refreshes our state
+// when another user toggles the pad-wide checkbox.
+exports.handleClientMessage_CLIENT_MESSAGE = statsToggle.handleClientMessage_CLIENT_MESSAGE;
+
 const stats = {
   init: () => {
     stats.update();
@@ -198,19 +216,18 @@ stats.authors = {
 };
 
 exports.postAceInit = (hook, context) => {
-  stats.show();
-  /* on click */
-  $('#options-stats').on('click', () => {
-    if ($('#options-stats').is(':checked')) {
-      stats.show();
-    } else {
-      stats.hide();
-    }
+  statsToggle.init({
+    onChange: (enabled) => {
+      if (enabled) stats.show();
+      else stats.hide();
+    },
   });
 };
 
 exports.aceEditEvent = (hookName, event) => {
-  if ($('#options-stats').is(':checked')) { // if stats are enabled
+  // The helper keeps #options-stats in sync with the live toggle state,
+  // so a DOM check is still the simplest read path on the hot path.
+  if ($('#options-stats').is(':checked')) {
     if (event.callstack.docTextChanged && event.callstack.domClean) {
       stats.update();
     }

--- a/templates/stats_entry.ejs
+++ b/templates/stats_entry.ejs
@@ -1,4 +1,0 @@
-<p>
-  <input type="checkbox" id="options-stats" checked></input>
-  <label for="options-stats" data-l10n-id="ep_stats.stats_entry.show_pad_and_author_stats">Show Pad and Author stats</label>
-</p>


### PR DESCRIPTION
## Summary

- Replace the manual `eejsBlock_mySettings` template with `padToggle` from `ep_plugin_helpers`. Parallel User Settings / Pad Wide Settings checkboxes for free; helper owns markup, storage, broadcast, enforce, and i18n.
- Slim `static/js/stats.js` `postAceInit` to use `padToggle.init({onChange})` instead of hand-rolled click binding.
- Delete the `eejsBlock_dd_view` "Pad Statistics" entry. It rendered hardcoded English text inside `<a href='#' onclick=…>` — i18n hole, a11y hole (anchor-as-button), CSP-hostile, and bypassed the helper's state machine. The User Settings panel is the canonical home for the toggle and now offers both per-user and pad-wide control.
- **Side benefits:**
  - Adds per-user persistence (the previous version had none — the checkbox lost its state on reload).
  - The original render logic was buggy: `templates/stats_entry.ejs` hardcoded `checked` on the input regardless of `settings.ep_stats_default`, so the admin setting never actually flipped the default state. The helper's `defaultEnabled` is honored properly.
- Backward compat: existing installs that set the legacy top-level `ep_stats_default` key keep their behavior — `loadSettings` translates it into the helper's nested `defaultEnabled`. (Admins who set `ep_stats_default: false` now actually get an off-by-default pad, matching the apparent intent.)

## Test plan

- [x] `pnpm run lint` (no new errors/warnings — pre-existing test lint error unchanged)
- [ ] CI green (backend + frontend tests)
- [ ] Toggle off in User Settings hides the stats panel; re-enabling shows it.
- [ ] Reload preserves the chosen state.
- [ ] On a core that supports pad-wide passthrough (Etherpad ≥ 2.7.4 + `enablePluginPadOptions: true`), toggling Pad Wide Settings broadcasts to other users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)